### PR TITLE
Use default cursor for feature icons

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -110,6 +110,7 @@ h1, h2 {
 	height: 50px;
 	margin: 5px 10px;
 	color: #000;
+	cursor: default;
 }
 .features .feature .feature-text {
 	width: 100%;


### PR DESCRIPTION
Currently a text cursor is shown which is not correct.
