### PR TITLE
Adding DCAT-AP plugin

### DIFF
--- a/source/components.html
+++ b/source/components.html
@@ -317,4 +317,10 @@ nav_name: components
         <td>
         </td>
     </tr>
+    <tr>
+        <td><a href="https://github.com/Wikimedia-Sverige/DCAT">DCAT-AP for Wikibase</a></td>
+        <td>PHP script for creating a DCAT-AP description of a Wikibase instance.</td>
+        <td>
+        </td>
+    </tr>
 </table>


### PR DESCRIPTION
Adding the component for creating a DCAT-AP description (live on Wikidata since [gerrit:229128](https://gerrit.wikimedia.org/r/229128))
