### PR TITLE
Update README.md to fix sculpin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ This repo contains the resources of the [wikiba.se website](http://wikiba.se).
 
 ## Installation
 
-Get [Sculpin](https://sculpin.io/) if you do not have it yet:
-
-    curl -O https://download.sculpin.io/sculpin.phar
-    chmod +x sculpin.phar
-    mv sculpin.phar /usr/bin/sculpin
-
 Run the install command:
 
     composer install
@@ -20,16 +14,14 @@ Run the install command:
 
 For development:
 
-    sculpin generate --watch --server
+    vendor/bin/sculpin generate --watch --server
     
 For deployment:
 
-    sculpin generate --env=prod
+    vendor/bin/sculpin generate --env=prod
 
 ## Running the tests
 
 Change into the root directory of the project and run
 
     phpunit
-
-Note that you need to have "sculpin" available as command.


### PR DESCRIPTION
The method of installing sculpin does not work anymore. See:
https://sculpin.io/getstarted/